### PR TITLE
Adding Dataloader  support for image base extractor

### DIFF
--- a/src/pymdma/common/definitions.py
+++ b/src/pymdma/common/definitions.py
@@ -79,5 +79,5 @@ class EmbedderInterface(ABC):
         self.name = name
 
     @abstractmethod
-    def extract_features_dataloader(self, dataloader):
+    def _extract_features_dataloader(self, dataloader):
         pass

--- a/src/pymdma/image/input_layer.py
+++ b/src/pymdma/image/input_layer.py
@@ -208,11 +208,11 @@ class ImageInputLayer(InputLayer):
             extractor = ExtractorFactory.model_from_name(model_name) if extractor is None else extractor
 
         # extractor = model_instance if model_instance is not None else FeatureExtractor(model_name, device=self.device)
-        reference_feats, _labels, _reference_ids = extractor.extract_features_dataloader(
+        reference_feats, _labels, _reference_ids = extractor._extract_features_dataloader(
             self.reference_loader,
             device=self.device,
         )
-        synthetic_feats, _labels, synthetic_ids = extractor.extract_features_dataloader(
+        synthetic_feats, _labels, synthetic_ids = extractor._extract_features_dataloader(
             self.target_loader,
             device=self.device,
         )

--- a/src/pymdma/image/models/imagenet.py
+++ b/src/pymdma/image/models/imagenet.py
@@ -63,9 +63,9 @@ class ViTExtractor(BaseExtractor):
 
 
 class DinoExtractor(BaseExtractor):
-    def __init__(self, model_name) -> None:
+    def __init__(self, model_name, input_size: tuple[int, int] = (224, 224)) -> None:
         super().__init__(
-            input_size=(224, 224),
+            input_size=input_size,
             interpolation=Image.Resampling.BICUBIC,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
+from torchvision.transforms import transforms
 
 from pymdma.api.run_api import app
 from pymdma.config import data_dir
@@ -63,6 +64,19 @@ def image_feature_extractor():
         return ImageFeatureExtractor.model_from_name(name)
 
     return get_extractor
+
+
+@pytest.fixture(scope="module")
+def image_transforms():
+    def get_transforms(input_size: Tuple[int], interpolation: int = Image.BILINEAR):
+        return transforms.Compose(
+            [
+                transforms.Resize(input_size, interpolation=interpolation),
+                transforms.ToTensor(),
+            ]
+        )
+
+    return get_transforms
 
 
 # ###################################################################################################


### PR DESCRIPTION
fix: rename internal `extract_features_dataloader` to `_extract_features_dataloader` in image extractor
fix: simplified StandardTransform to work with tensors
feat: add simple implementation for dataloader feature extraction in image
docs: rewrote google style docs to numpydoc style

#28 