### PR TITLE
Time series dataset size error

### DIFF
--- a/src/pymdma/image/input_layer.py
+++ b/src/pymdma/image/input_layer.py
@@ -138,7 +138,6 @@ class ImageInputLayer(InputLayer):
                 reference_dataset,
                 batch_size=self.batch_size if self.batch_size > 0 else len(reference_files),
                 shuffle=False,
-                num_workers=4,
                 collate_fn=collate_fn,  # no need to collate images
             )
 
@@ -152,7 +151,6 @@ class ImageInputLayer(InputLayer):
             target_dataset,
             batch_size=self.batch_size if self.batch_size > 0 else len(target_files),
             shuffle=False,
-            num_workers=4,
             collate_fn=collate_fn,  # no need to collate images
         )
 

--- a/src/pymdma/time_series/input_layer.py
+++ b/src/pymdma/time_series/input_layer.py
@@ -131,7 +131,6 @@ class TimeSeriesInputLayer(InputLayer):
                 reference_dataset,
                 batch_size=self.batch_size if self.batch_size > 0 else len(reference_files),
                 shuffle=False,
-                num_workers=4,
                 collate_fn=collate_fn,
             )
 
@@ -142,7 +141,6 @@ class TimeSeriesInputLayer(InputLayer):
             target_dataset,
             batch_size=self.batch_size if self.batch_size > 0 else len(target_dataset),
             shuffle=False,
-            num_workers=4,
             collate_fn=collate_fn,
         )
 
@@ -207,15 +205,17 @@ class TimeSeriesInputLayer(InputLayer):
                 yield (no_ref_signals,)
         else:  # full reference
             # iterate through both dataloaders and yield batches of signals
-            ref_iter, sim_iter = iter(self.reference_loader), iter(self.target_loader)
-            for _ in range(len(self.reference_loader)):
-                ref_sigs, _, _ = next(ref_iter)
-                sim_sigs, _, _sig_ids = next(sim_iter)
-
-                # save signal ids for later
-                # self.instance_ids.extend(list(sig_ids))
-
-                yield ref_sigs, sim_sigs
+            ref_sigs = []
+            for ref_sig in self.reference_loader:
+                ref_sig, _, _sig_ids = ref_sig
+                ref_sigs.extend(ref_sig)
+            
+            sim_sigs = []
+            for sim_sig in self.target_loader:
+                sim_sig, _, _sig_ids = sim_sig
+                sim_sigs.extend(sim_sig)
+            yield (np.array(ref_sigs), np.array(sim_sigs))
+            
 
     def get_full_samples(self):
         # only reference signals for no reference metrics

--- a/src/pymdma/time_series/measures/synthesis_val/data/freq_sim.py
+++ b/src/pymdma/time_series/measures/synthesis_val/data/freq_sim.py
@@ -212,6 +212,7 @@ class SpectralWassersteinDistance(Metric):
         MetricResult
             Dataset-level results for the Spectral Coherence.
         """
+        
         real_psd = self._compute_power_spectral_density(real_data)
         syn_psd = self._compute_power_spectral_density(syn_data)
 

--- a/tests/test_ts_import.py
+++ b/tests/test_ts_import.py
@@ -768,7 +768,7 @@ def test_reproducibility(metric_name, expected, show_dist=False):
 @pytest.mark.parametrize(
     "metric, expected",
     [
-        (SpectralCoherence, 0.02950173805071692),
+        (SpectralCoherence, 0.029512458757103333),
         (SpectralWassersteinDistance, 0.041511867769033095),
     ],
 )


### PR DESCRIPTION
Metric computations in data-based synthetic augmentation cause problems when using datasets with different sizes.
Minor fix on the API input layer. Does not affect metric computations.